### PR TITLE
Remove include exif timestamp parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Returns a Promise with photo identifier objects from the local camera roll of th
   * `Videos`
   * `Photos` // default
 * `mimeTypes` : {Array} : Filter by mimetype (e.g. image/jpeg).
-* `includeExifTimestamp`: {boolean} : Include the exif timestamp for the photo // Android only
 
 Returns a Promise which when resolved will be of the following shape:
 

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -26,7 +26,6 @@ declare namespace CameraRoll {
     groupName?: string;
     assetType?: AssetType;
     mimeTypes?: Array<string>;
-    includeExifTimestamp?: boolean;
   }
 
   interface PhotoIdentifier {


### PR DESCRIPTION
We have to use the exif interface now anyway for to retrieve location data, there is almost no extra cost anymore to include the exif timestamp.