### PR TITLE
Android 10 timestamp fix

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -315,7 +315,11 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       WritableMap response = new WritableNativeMap();
       ContentResolver resolver = mContext.getContentResolver();
 
+      // TODO: Remove this when updating the project.
+      // DATE_TAKEN can result in images having a timestamp of zero on Android 10+, hence we use DATE_ADDED
+      // in that case.
       String mediaQuery = Build.VERSION.SDK_INT >= 29 ? Images.Media.DATE_ADDED : Images.Media.DATE_TAKEN;
+
       // using LIMIT in the sortOrder is not explicitly supported by the SDK (which does not support
       // setting a limit at all), but it works because this specific ContentProvider is backed by
       // an SQLite DB and forwards parameters to it without doing any parsing / validation.

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -330,10 +330,10 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       ContentResolver resolver = mContext.getContentResolver();
 
       // set LIMIT to first + 1 so that we know how to populate page_info
-      String sortQuery = mUseDateAddedQuery ? (Images.Media.DATE_ADDED + " DESC, ") : ""
-          + Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED
-              + " DESC LIMIT " + (mFirst + 1); 
-                  
+      String sortQuery = (mUseDateAddedQuery ? Images.Media.DATE_ADDED + " DESC, " : "")
+          + Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT "
+              + (mFirst + 1);
+
       // using LIMIT in the sortOrder is not explicitly supported by the SDK (which
       // does not support setting a limit at all), but it works because this specific 
       // ContentProvider is backed by an SQLite DB and forwards parameters to it without 

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -315,11 +315,6 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       WritableMap response = new WritableNativeMap();
       ContentResolver resolver = mContext.getContentResolver();
 
-      // TODO: Remove this when updating the project.
-      // DATE_TAKEN can result in images having a timestamp of zero on Android 10+, hence we use DATE_ADDED
-      // in that case.
-      String mediaQuery = Build.VERSION.SDK_INT >= 29 ? Images.Media.DATE_ADDED : Images.Media.DATE_TAKEN;
-
       // using LIMIT in the sortOrder is not explicitly supported by the SDK (which does not support
       // setting a limit at all), but it works because this specific ContentProvider is backed by
       // an SQLite DB and forwards parameters to it without doing any parsing / validation.
@@ -329,7 +324,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
             PROJECTION,
             selection.toString(),
             selectionArgs.toArray(new String[selectionArgs.size()]),
-            mediaQuery + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+            Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
                     (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
         if (media == null) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not get media");

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -365,14 +365,14 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     }
   }
 
-  private static void putPageInfo(Cursor media, WritableMap response, int limit, boolean useDateAddedQuery) {
+  private static void putPageInfo(Cursor media, WritableMap response, int limit, boolean useDateAdded) {
     WritableMap pageInfo = new WritableNativeMap();
     pageInfo.putBoolean("has_next_page", limit < media.getCount());
     if (limit < media.getCount()) {
       media.moveToPosition(limit - 1);
       int dateTakenIndex = media.getColumnIndex(Images.Media.DATE_TAKEN);
       int dateAddedIndex = media.getColumnIndex(Images.Media.DATE_ADDED);
-      int columnIndex = useDateAddedQuery ? Math.max(dateAddedIndex, dateTakenIndex)
+      int columnIndex = useDateAdded ? Math.max(dateAddedIndex, dateTakenIndex)
           : dateTakenIndex;
       pageInfo.putString(
           "end_cursor", 
@@ -386,7 +386,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       Cursor media,
       WritableMap response,
       int limit,
-      boolean useDateAddedQuery) {
+      boolean useDateAdded) {
     WritableArray edges = new WritableNativeArray();
     media.moveToFirst();
     int idIndex = media.getColumnIndex(Images.Media._ID);
@@ -402,7 +402,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       WritableMap edge = new WritableNativeMap();
       WritableMap node = new WritableNativeMap();
       ExifInterface exif = getExifInterface(media, dataIndex);
-      int timestamp = useDateAddedQuery ? Math.max(dateAddedIndex, dateTakenIndex) : dateTakenIndex;
+      int timestamp = useDateAdded ? Math.max(dateAddedIndex, dateTakenIndex) : dateTakenIndex;
       boolean imageInfoSuccess = exif != null &&
           putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex, mimeTypeIndex, exif);
       if (imageInfoSuccess) {

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -297,25 +297,28 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
         selectionArgs.add(mGroupName);
       }
 
-      if (mAssetType.equals(ASSET_TYPE_PHOTOS)) {
-        selection.append(" AND " + MediaStore.Files.FileColumns.MEDIA_TYPE + " = "
-          + MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE);
-      } else if (mAssetType.equals(ASSET_TYPE_VIDEOS)) {
-        selection.append(" AND " + MediaStore.Files.FileColumns.MEDIA_TYPE + " = "
-          + MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO);
-      } else if (mAssetType.equals(ASSET_TYPE_ALL)) {
-        selection.append(" AND " + MediaStore.Files.FileColumns.MEDIA_TYPE + " IN ("
-          + MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO + ","
-          + MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE + ")");
-      } else {
-        mPromise.reject(
-          ERROR_UNABLE_TO_FILTER,
-          "Invalid filter option: '" + mAssetType + "'. Expected one of '"
-            + ASSET_TYPE_PHOTOS + "', '" + ASSET_TYPE_VIDEOS + "' or '" + ASSET_TYPE_ALL + "'."
-        );
-        return;
+      switch (mAssetType) {
+        case ASSET_TYPE_PHOTOS:
+          selection.append(" AND " + MediaStore.Files.FileColumns.MEDIA_TYPE + " = "
+              + MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE);
+          break;
+        case ASSET_TYPE_VIDEOS:
+          selection.append(" AND " + MediaStore.Files.FileColumns.MEDIA_TYPE + " = "
+              + MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO);
+          break;
+        case ASSET_TYPE_ALL:
+          selection.append(" AND " + MediaStore.Files.FileColumns.MEDIA_TYPE + " IN ("
+              + MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO + ","
+              + MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE + ")");
+          break;
+        default:
+          mPromise.reject(
+              ERROR_UNABLE_TO_FILTER,
+              "Invalid filter option: '" + mAssetType + "'. Expected one of '" + ASSET_TYPE_PHOTOS
+                  + "', '" + ASSET_TYPE_VIDEOS + "' or '" + ASSET_TYPE_ALL + "'."
+          );
+          return;
       }
-
 
       if (mMimeTypes != null && mMimeTypes.size() > 0) {
         selection.append(" AND " + Images.Media.MIME_TYPE + " IN (");
@@ -423,8 +426,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     Uri photoUri = Uri.parse("file://" + media.getString(dataIndex));
     File file = new File(media.getString(dataIndex));
     try {
-      ExifInterface exif = new ExifInterface(file.getPath());
-      return exif;
+      return new ExifInterface(file.getPath());
     } catch (IOException e) {
       FLog.e(ReactConstants.TAG, "Could not get exifTimestamp for " + photoUri.toString(), e);
       return null;

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -318,13 +318,21 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       // an SQLite DB and forwards parameters to it without doing any parsing / validation.
       try {
         Cursor media = resolver.query(
-            MediaStore.Files.getContentUri("external"),
-            PROJECTION,
-            selection.toString(),
-            selectionArgs.toArray(new String[selectionArgs.size()]),
-            Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
-                (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
-        if (media == null) {
+                MediaStore.Files.getContentUri("external"),
+                PROJECTION,
+                selection.toString(),
+                selectionArgs.toArray(new String[selectionArgs.size()]),
+                Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+                        (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
+        if (media != null && media.getCount() <= 0) {
+          media = resolver.query(
+                  MediaStore.Files.getContentUri("external"),
+                  PROJECTION,
+                  selection.toString(),
+                  selectionArgs.toArray(new String[selectionArgs.size()]),
+                  Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+                          (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
+        } else if (media == null) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not get media");
         } else {
           try {

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -232,6 +232,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     ReadableArray mimeTypes = params.hasKey("mimeTypes")
         ? params.getArray("mimeTypes")
         : null;
+    String additionalPropertyQuery = params.hasKey("additionalPropertyQuery") ?
+            params.getString("additionalPropertyQuery") : null;
 
     new GetMediaTask(
           getReactApplicationContext(),
@@ -240,6 +242,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           groupName,
           mimeTypes,
           assetType,
+          additionalPropertyQuery,
           promise)
           .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
   }
@@ -250,6 +253,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     private final @Nullable String mAfter;
     private final @Nullable String mGroupName;
     private final @Nullable ReadableArray mMimeTypes;
+    private final @Nullable String mAdditionalPropertyQuery;
     private final Promise mPromise;
     private final String mAssetType;
 
@@ -259,6 +263,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
         @Nullable String after,
         @Nullable String groupName,
         @Nullable ReadableArray mimeTypes,
+        @Nullable String additionalPropertyQuery,
         String assetType,
         Promise promise) {
       super(context);
@@ -269,6 +274,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       mMimeTypes = mimeTypes;
       mPromise = promise;
       mAssetType = assetType;
+      mAdditionalPropertyQuery = additionalPropertyQuery;
     }
 
     @Override
@@ -324,7 +330,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
             PROJECTION,
             selection.toString(),
             selectionArgs.toArray(new String[selectionArgs.size()]),
-            Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+            Images.Media.DATE_TAKEN + " DESC, " + mAdditionalPropertyQuery + " DESC, " + Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
                     (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
         if (media == null) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not get media");

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -389,7 +389,6 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       boolean useDateAdded) {
     WritableArray edges = new WritableNativeArray();
     media.moveToFirst();
-    int idIndex = media.getColumnIndex(Images.Media._ID);
     int mimeTypeIndex = media.getColumnIndex(Images.Media.MIME_TYPE);
     int groupNameIndex = media.getColumnIndex(Images.Media.BUCKET_DISPLAY_NAME);
     int dateTakenIndex = media.getColumnIndex(Images.Media.DATE_TAKEN);
@@ -404,10 +403,10 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       ExifInterface exif = getExifInterface(media, dataIndex);
       int timestamp = useDateAdded ? Math.max(dateAddedIndex, dateTakenIndex) : dateTakenIndex;
       boolean imageInfoSuccess = exif != null &&
-          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex, mimeTypeIndex, exif);
+          putImageInfo(resolver, media, node, widthIndex, heightIndex, dataIndex, mimeTypeIndex, exif);
       if (imageInfoSuccess) {
         putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, timestamp);
-        putLocationInfo(media, node, dataIndex, exif);
+        putLocationInfo(node, exif);
 
         edge.putMap("node", node);
         edges.pushMap(edge);
@@ -448,7 +447,6 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       ContentResolver resolver,
       Cursor media,
       WritableMap node,
-      int idIndex,
       int widthIndex,
       int heightIndex,
       int dataIndex,
@@ -537,9 +535,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
   }
 
   private static void putLocationInfo(
-      Cursor media,
       WritableMap node,
-      int dataIndex,
       ExifInterface exif) {
       // location details are no longer indexed for privacy reasons using string Media.LATITUDE, Media.LONGITUDE
       // we manually obtain location metadata using ExifInterface#getLatLong(float[]).

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -318,20 +318,20 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       // an SQLite DB and forwards parameters to it without doing any parsing / validation.
       try {
         Cursor media = resolver.query(
-                MediaStore.Files.getContentUri("external"),
-                PROJECTION,
-                selection.toString(),
-                selectionArgs.toArray(new String[selectionArgs.size()]),
-                Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
-                        (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
+            MediaStore.Files.getContentUri("external"),
+            PROJECTION,
+            selection.toString(),
+            selectionArgs.toArray(new String[selectionArgs.size()]),
+            Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+                    (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
         if (media != null && media.getCount() <= 0) {
           media = resolver.query(
-                  MediaStore.Files.getContentUri("external"),
-                  PROJECTION,
-                  selection.toString(),
-                  selectionArgs.toArray(new String[selectionArgs.size()]),
-                  Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
-                          (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
+              MediaStore.Files.getContentUri("external"),
+              PROJECTION,
+              selection.toString(),
+              selectionArgs.toArray(new String[selectionArgs.size()]),
+              Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+                      (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
         } else if (media == null) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not get media");
         } else {

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -24,7 +24,6 @@ import android.text.TextUtils;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.GuardedAsyncTask;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -236,7 +236,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     String groupName = params.hasKey("groupName") ? params.getString("groupName") : null;
     String assetType = params.hasKey("assetType") ? params.getString("assetType") : ASSET_TYPE_PHOTOS;
     ReadableArray mimeTypes = params.hasKey("mimeTypes") 
-        ? params.getArray("mimeTypes") : null;
+        ? params.getArray("mimeTypes") 
+        : null;
     boolean useDateDateAddedQuery = params.hasKey("useDateAddedQuery")
         ? params.getBoolean("useDateAddedQuery")
         : false;

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -18,6 +18,8 @@ declare namespace CameraRoll {
     | 'SavedPhotos';
 
   type AssetType = 'All' | 'Videos' | 'Photos';
+  
+  type ImageQueryProperty = 'date_added';
 
   interface GetPhotosParams {
     first: number;
@@ -26,6 +28,7 @@ declare namespace CameraRoll {
     groupName?: string;
     assetType?: AssetType;
     mimeTypes?: Array<string>;
+    additionalPropertyQuery?: ImageQueryProperty;
   }
 
   interface PhotoIdentifier {

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -26,7 +26,7 @@ declare namespace CameraRoll {
     groupName?: string;
     assetType?: AssetType;
     mimeTypes?: Array<string>;
-    UseDateAddedQuery?: boolean;
+    useDateAddedQuery?: boolean;
   }
 
   interface PhotoIdentifier {

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -18,8 +18,6 @@ declare namespace CameraRoll {
     | 'SavedPhotos';
 
   type AssetType = 'All' | 'Videos' | 'Photos';
-  
-  type ImageQueryProperty = 'date_added';
 
   interface GetPhotosParams {
     first: number;
@@ -28,7 +26,7 @@ declare namespace CameraRoll {
     groupName?: string;
     assetType?: AssetType;
     mimeTypes?: Array<string>;
-    additionalPropertyQuery?: ImageQueryProperty;
+    UseDateAddedQuery?: boolean;
   }
 
   interface PhotoIdentifier {


### PR DESCRIPTION
~This PR changes the query of media load based on the used Android version. This should be a temporary fix, as we cannot yet easily update the version of the app.~

~@FrikkieSnyman @bryanvanwijk It would be nice if we can update this project in the near future: the latest release includes features for returning images in a timeframe, thus requiring less loading, memory, and post-processing from our side, as we now load all images from timestamp X and filter out any that are not within the activity timeframe afterwards.~

~--- Update~
~See comment at the bottom of this thread.~

---
# Final Update
@FrikkieSnyman here are my notes on what changed.

This PR changes some behaviour in the SQL queries and cleans up the code base a bit:

- The query itself now takes `date_added` into account when `date_taken` appears to be invalid (i.e., <= 0).
- When sorting the results, the same concept is adhered to.
- We now, thus, also return `date_added` as a timestamp for an image and as the cursor for the returned data if applicable. As `date_added` is measured in time in seconds, this number is multiplied by 1000 when it is used as a cursor. This can result in duplicate results when a user has more than 100 pictures and multiple taken per second in case we query for a timestamp that does not contain any milliseconds information. This, then, can occur due to images having the same timestamp due to them being taken within the same second. However, this is no issue as we filter out any duplicates and due to the quantity of images required and the requirement of multiple images being taken per second for this to occur, we can consider this an edge case that will still be resolved on the mobileapp side.
- TODO: I feel that we can clear up quite some logic in the app by introducing a new parameter that also includes a lower bound (timestamp wise) for the search query (as is the case in the latest release of this package).