### PR TITLE
Exif date time original api compatibility

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -559,12 +559,18 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     node.putMap("image", image);
     try {
       String exifTimestampString = null;
-      if (useExifDateTimeOriginal && exif.hasAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)) {
-        exifTimestampString = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL);
-      } else {
-        exifTimestampString = exif.getAttribute(ExifInterface.TAG_DATETIME);
+
+      if (useExifDateTimeOriginal) {
+        String exifDateTimeOriginal = exif.getAttribute("DateTimeOriginal");
+        if (exifDateTimeOriginal != null) {
+          exifTimestampString = exifDateTimeOriginal;
+        }
       }
-      
+
+      if (exifTimestampString == null) {
+        exifTimestampString = exif.getAttribute("DateTime");
+      }
+
       if (exifTimestampString != null) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
         Date d = sdf.parse(exifTimestampString);


### PR DESCRIPTION
Avoid using `.hasAttribute` which [caused exceptions ](https://console.firebase.google.com/u/0/project/relive-1483378336491/crashlytics/app/android:cc.relive.reliveapp/issues/a2446334bbd4af776148625a97c86b8b?time=last-seven-days&sessionEventKey=604362B000C0000143A2C430ED0E4DE9_1514986385823571788) and do not use to allow older api support.